### PR TITLE
Remove errant trailing slash from skos:Concept URI.

### DIFF
--- a/core/vocabularies/rbms_binding_type/0.1/rbms_binding_type.rdf
+++ b/core/vocabularies/rbms_binding_type/0.1/rbms_binding_type.rdf
@@ -3,13 +3,13 @@
          xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
          xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
          xmlns:skos="http://www.w3.org/2004/02/skos/core#">
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin1">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin1">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Accordion fold format</skos:prefLabel>
       <skos:altLabel xml:lang="en">Double leaf format</skos:altLabel>
       <skos:altLabel xml:lang="en">Orihon format</skos:altLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin4"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin4"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -27,14 +27,14 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin5">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin5">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Adhesive bindings</skos:prefLabel>
       <skos:altLabel xml:lang="en">Perfect bindings</skos:altLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin7"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin8"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin9"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin7"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin8"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin9"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -52,12 +52,12 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin10">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin10">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">All along sewing</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin11"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin12"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin11"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin12"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -75,11 +75,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin13">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin13">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">All-over style bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin14"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin14"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -97,14 +97,14 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin15">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin15">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Alum tawed bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin16"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin17"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin18"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin19"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin16"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin17"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin18"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin19"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -122,11 +122,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin20">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin20">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Alum tawed thongs</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin21"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin21"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -144,11 +144,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin22">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin22">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Aluminum bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin16"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin16"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -166,16 +166,16 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin23">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin23">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Ancillary structures (Gathering term; do not assign)</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin24"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin25"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin26"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin27"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin28"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin29"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin24"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin25"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin26"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin27"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin28"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin29"/>
       <skos:scopeNote xml:lang="en">Gathering term; do not use; index under a narrower term.</skos:scopeNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
@@ -199,12 +199,12 @@
          <dcterms:date>2000-01-01</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin32">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin32">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Apollo and Pegasus bindings</skos:prefLabel>
       <skos:altLabel xml:lang="en">Canevari bindings</skos:altLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin34"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin34"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -222,12 +222,12 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin35">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin35">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Architectural bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin14"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin36"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin14"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin36"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -245,14 +245,14 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin37">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin37">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Armorial bindings</skos:prefLabel>
       <skos:altLabel xml:lang="en">Heraldic bindings</skos:altLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin34"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin39"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin40"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin34"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin39"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin40"/>
       <skos:scopeNote xml:lang="en">Bindings with a coat of arms, or any part of a coat of arms, e.g., a crest.</skos:scopeNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
@@ -271,12 +271,12 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin423">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin423">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Art Deco bindings</skos:prefLabel>
       <skos:altLabel xml:lang="en">Bindings, Art Deco</skos:altLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin14"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin14"/>
       <skos:scopeNote xml:lang="en">Use for bindings produced during the 1920s and 1930s, in Art Deco style, often characterized by sleek, geometric, or stylized forms.</skos:scopeNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
@@ -295,11 +295,11 @@
          <dcterms:date>2009-10-16</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin43">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin43">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Backless bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin7"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin7"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -317,18 +317,18 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin44">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin44">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Bands</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin45"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin192"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin46"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin47"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin48"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin49"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin50"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin21"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin45"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin192"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin46"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin47"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin48"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin49"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin50"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin21"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -346,13 +346,13 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin51">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin51">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Bevelled edge boards</skos:prefLabel>
       <skos:altLabel xml:lang="en">Chamfered edge boards</skos:altLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin52"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin53"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin52"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin53"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -370,12 +370,12 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin55">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin55">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Binders' bills</skos:prefLabel>
       <skos:altLabel xml:lang="en">Bills, binders'</skos:altLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin56"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin56"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -393,15 +393,15 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin56">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin56">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Binders' evidence (Gathering term; do not assign)</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin55"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin57"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin58"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin59"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin60"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin55"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin57"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin58"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin59"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin60"/>
       <skos:scopeNote xml:lang="en">Gathering term; do not use; index under a narrower term.</skos:scopeNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
@@ -420,12 +420,12 @@
          <dcterms:date>2007-08-03</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin57">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin57">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Binders' instructions</skos:prefLabel>
       <skos:altLabel xml:lang="en">Instructions, binders'</skos:altLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin56"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin56"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -443,12 +443,12 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin58">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin58">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Binders' receipts</skos:prefLabel>
       <skos:altLabel xml:lang="en">Receipts, binders'</skos:altLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin56"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin56"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -466,13 +466,13 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin59">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin59">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Binders' tickets</skos:prefLabel>
       <skos:altLabel xml:lang="en">Tickets, binders'</skos:altLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin56"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin60"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin56"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin60"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -490,13 +490,13 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin64">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin64">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Binding errors</skos:prefLabel>
       <skos:altLabel xml:lang="en">Errors in binding</skos:altLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin66"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin67"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin66"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin67"/>
       <skos:scopeNote xml:lang="en">For any kind of errors in binding, except folding errors.</skos:scopeNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
@@ -515,17 +515,17 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin69">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin69">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Binding labels</skos:prefLabel>
       <skos:altLabel xml:lang="en">Spine labels</skos:altLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin204"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin146"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin293"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin219"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin203"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin205"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin204"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin146"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin293"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin219"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin203"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin205"/>
       <skos:historyNote xml:lang="en">Changed 6/2016. Formerly, "Binding labels" may have been indexed as "Labels."</skos:historyNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
@@ -549,16 +549,16 @@
          <dcterms:date>2000-01-01</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin71">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin71">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Blind tooled bindings</skos:prefLabel>
       <skos:altLabel xml:lang="en">Blind rolled bindings</skos:altLabel>
       <skos:altLabel xml:lang="en">Blind stamped bindings</skos:altLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin73"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin74"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin75"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin76"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin73"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin74"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin75"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin76"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -576,14 +576,14 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin79">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin79">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Blocked bindings</skos:prefLabel>
       <skos:altLabel xml:lang="en">Plaque-impressed bindings</skos:altLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin73"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin80"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin413"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin73"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin80"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin413"/>
       <skos:scopeNote xml:lang="en">Use for cloth or leather bindings, originally appearing in the 1820s, with blind, gilt, or color designs made from the impression of relief blocks.</skos:scopeNote>
       <skos:historyNote xml:lang="en">Scope note added 6/2007; disambiguated from "panel-stamped bindings" based on literary warrant.</skos:historyNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
@@ -603,16 +603,16 @@
          <dcterms:date>2007-08-03</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin81">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin81">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Board fastenings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin82"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin83"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin84"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin85"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin86"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin87"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin82"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin83"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin84"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin85"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin86"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin87"/>
       <skos:scopeNote xml:lang="en">Gathering term; do not use; index under a narrower term.</skos:scopeNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
@@ -631,15 +631,15 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin88">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin88">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Boards</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin7"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin52"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin89"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin90"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin91"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin7"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin52"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin89"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin90"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin91"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -657,8 +657,8 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin94">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin94">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Bookbinding (Assign only with subdivisions)</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
       <skos:scopeNote xml:lang="en">Use only with subdivisions, to identify noteworthy binding types, styles, and techniques which cannot be otherwise classified using terms on this list.</skos:scopeNote>
@@ -684,12 +684,12 @@
          <dcterms:date>2000-01-01</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin95">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin95">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Bosses</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin96"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin97"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin96"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin97"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -707,11 +707,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin97">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin97">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Brass bosses</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin95"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin95"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -729,11 +729,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin100">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin100">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Brass clasps</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin101"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin101"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -751,12 +751,12 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin102">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin102">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Brocade bindings</skos:prefLabel>
       <skos:altLabel xml:lang="en">Silk brocade bindings</skos:altLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin104"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin104"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -774,11 +774,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin112">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin112">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Buttonhole stitched headbands</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin113"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin113"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -796,15 +796,15 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin114">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin114">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Calf bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin18"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin322"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin343"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin388"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin323"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin18"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin322"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin343"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin388"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin323"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -822,12 +822,12 @@
          <dcterms:date>2007-08-03</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin8">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin8">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Caoutchouc bindings</skos:prefLabel>
       <skos:altLabel xml:lang="en">Gutta percha bindings</skos:altLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin5"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin5"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -845,11 +845,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin118">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin118">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Case bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin7"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin7"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -867,17 +867,17 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin83">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin83">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Catches</skos:prefLabel>
       <skos:altLabel xml:lang="en">Pins</skos:altLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin81"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin126"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin84"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin85"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin86"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin87"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin81"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin126"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin84"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin85"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin86"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin87"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -895,16 +895,16 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin119">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin119">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Categories of bindings/Occasions for binding (Gathering term;do not assign)</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin120"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin121"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin122"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin123"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin34"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin124"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin120"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin121"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin122"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin123"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin34"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin124"/>
       <skos:scopeNote xml:lang="en">Gathering term; do not use; index under a narrower term.</skos:scopeNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
@@ -928,12 +928,12 @@
          <dcterms:date>2000-01-01</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin36">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin36">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Cathedral bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin14"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin35"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin14"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin35"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -951,13 +951,13 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin127">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin127">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Centerpiece and cornerpiece bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin14"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin128"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin155"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin14"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin128"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin155"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -975,13 +975,13 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin128">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin128">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Centerpieces (Designs)</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin14"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin127"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin155"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin14"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin127"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin155"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -999,12 +999,12 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin129">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin129">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Centerpieces (Furniture)</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin96"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin130"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin96"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin130"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -1022,12 +1022,12 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin131">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin131">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Chained bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin82"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin96"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin82"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin96"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -1045,11 +1045,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin133">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin133">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Chemises</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin134"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin134"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -1067,13 +1067,13 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin135">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin135">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Circuit edges</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin7"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin136"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin137"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin7"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin136"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin137"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -1091,14 +1091,14 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin427">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin427">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Clamshell boxes</skos:prefLabel>
       <skos:altLabel xml:lang="en">Boxes, clamshell</skos:altLabel>
       <skos:altLabel xml:lang="en">Double tray boxes</skos:altLabel>
       <skos:altLabel xml:lang="en">Drop spine boxes</skos:altLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin134"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin134"/>
       <skos:scopeNote xml:lang="en">Use for box structures that include two three-sided trays (one made to fit inside the other when closed) attached to a case.</skos:scopeNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
@@ -1117,14 +1117,14 @@
          <dcterms:date>2014-05-16</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin84">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin84">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Clasp plates</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin81"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin138"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin83"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin85"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin81"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin138"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin83"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin85"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -1142,17 +1142,17 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin85">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin85">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Clasps</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin81"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin139"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin101"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin83"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin84"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin86"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin87"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin81"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin139"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin101"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin83"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin84"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin86"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin87"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -1170,11 +1170,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin146">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin146">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Cloth binding labels</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin69"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin69"/>
       <skos:historyNote xml:lang="en">Changed 6/2016. Formerly, "Cloth binding labels" may have been indexed as "Cloth labels."</skos:historyNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
@@ -1198,18 +1198,18 @@
          <dcterms:date>2000-01-01</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin104">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin104">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Cloth bindings</skos:prefLabel>
       <skos:altLabel xml:lang="en">Textile bindings</skos:altLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin16"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin102"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin141"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin142"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin143"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin144"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin145"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin16"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin102"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin141"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin142"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin143"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin144"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin145"/>
       <skos:scopeNote xml:lang="en">Not for publishers&#x92; cloth; primarily for 16th-17th century bindings covered in cloth.</skos:scopeNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
@@ -1228,11 +1228,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin147">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin147">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Cloth tapes</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin50"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin50"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -1250,12 +1250,12 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin148">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin148">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Cloth wrappers</skos:prefLabel>
       <skos:altLabel xml:lang="en">Printed cloth wrappers</skos:altLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin150"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin150"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -1273,11 +1273,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin419">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin419">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Comb bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin418"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin418"/>
       <skos:scopeNote xml:lang="en">Use for bindings in which the curved prongs of a strip of metal, plastic, etc., pass through a series of holes in a margin of the text block.</skos:scopeNote>
       <skos:historyNote xml:lang="en">Approved 6/2008</skos:historyNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
@@ -1297,13 +1297,13 @@
          <dcterms:date>2008-07-11</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin120">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin120">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Contemporary bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin119"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin121"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin124"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin119"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin121"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin124"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -1321,11 +1321,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin151">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin151">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Coptic bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin14"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin14"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -1343,17 +1343,17 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin49">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin49">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Cords</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin45"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin152"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin153"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin154"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin44"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin50"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin21"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin45"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin152"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin153"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin154"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin44"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin50"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin21"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -1371,13 +1371,13 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin155">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin155">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Cornerpieces (Designs)</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin14"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin127"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin128"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin14"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin127"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin128"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -1395,12 +1395,12 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin130">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin130">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Cornerpieces (Furniture)</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin96"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin129"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin96"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin129"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -1418,13 +1418,13 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin156">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin156">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Corrugated board bindings</skos:prefLabel>
       <skos:altLabel xml:lang="en">Corrugated cardboard bindings</skos:altLabel>
       <skos:altLabel xml:lang="en">Corrugated paper bindings</skos:altLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin159"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin159"/>
       <skos:scopeNote xml:lang="en">Use for bindings made of corrugated board.</skos:scopeNote>
       <skos:historyNote xml:lang="en">Rem added 7/00.</skos:historyNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
@@ -1444,11 +1444,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin160">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin160">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Cosway bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin14"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin14"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -1466,11 +1466,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin161">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin161">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Cottage style bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin14"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin14"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -1488,11 +1488,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin162">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin162">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Cottonian Library book covers</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin34"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin34"/>
       <skos:scopeNote xml:lang="en">Robert Southey&#x92;s cloth book covers.</skos:scopeNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
@@ -1511,13 +1511,13 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin165">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin165">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Cuir-ciselé bindings</skos:prefLabel>
       <skos:altLabel xml:lang="en">Cut leather bindings</skos:altLabel>
       <skos:altLabel xml:lang="en">Lederschnitt bindings</skos:altLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin18"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin18"/>
       <skos:note xml:lang="en">"Cuir-ciselé or cut leather is a self-explanatory decorative technique: the leather is given patterns inscribed by a knife or other sharp tool."--Needham</skos:note>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
@@ -1536,18 +1536,18 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin170">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin170">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Decorated edges</skos:prefLabel>
       <skos:altLabel xml:lang="en">Edge decoration</skos:altLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin171"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin173"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin253"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin174"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin175"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin176"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin177"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin171"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin173"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin253"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin174"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin175"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin176"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin177"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -1565,22 +1565,22 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin108">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin108">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Decorated paper bindings</skos:prefLabel>
       <skos:altLabel xml:lang="en">Buntpapier</skos:altLabel>
       <skos:altLabel xml:lang="en">Patterned papers</skos:altLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin16"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin179"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin180"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin181"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin182"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin183"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin184"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin185"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin186"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin187"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin16"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin179"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin180"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin181"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin182"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin183"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin184"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin185"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin186"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin187"/>
       <skos:scopeNote xml:lang="en">Use for the occurrence of such papers as any part of bindings, cases, endpapers, or doublures.</skos:scopeNote>
       <skos:historyNote xml:lang="en">Changed 6/2016. Formerly, "Decorated paper bindings" may have been indexed as "Decorated papers."</skos:historyNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
@@ -1605,13 +1605,13 @@
          <dcterms:date>2000-01-01</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin106">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin106">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Deerskin bindings</skos:prefLabel>
       <skos:altLabel xml:lang="en">Buckskin bindings</skos:altLabel>
       <skos:altLabel xml:lang="en">Doeskin bindings</skos:altLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin18"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin18"/>
       <skos:historyNote xml:lang="en">Term added 2/97.</skos:historyNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
@@ -1630,12 +1630,12 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin190">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin190">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Dentelle bindings</skos:prefLabel>
       <skos:altLabel xml:lang="en">Lace bindings (Designs)</skos:altLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin14"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin14"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -1653,11 +1653,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin191">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin191">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Diced leather bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin18"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin18"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -1675,11 +1675,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin192">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin192">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Disguised bands</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin44"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin44"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -1697,11 +1697,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin398">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin398">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Dos-à-dos bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin7"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin7"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -1719,11 +1719,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin46">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin46">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Double bands</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin44"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin44"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -1741,11 +1741,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin152">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin152">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Double cords</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin49"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin49"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -1763,11 +1763,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin193">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin193">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Double fore-edge paintings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin194"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin194"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -1785,16 +1785,16 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin24">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin24">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Doublures</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin23"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin195"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin196"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin197"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin198"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin199"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin23"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin195"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin196"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin197"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin198"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin199"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -1812,13 +1812,13 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin93">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin93">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Dust jackets</skos:prefLabel>
       <skos:altLabel xml:lang="en">Book jackets</skos:altLabel>
       <skos:altLabel xml:lang="en">Dust wrappers</skos:altLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin134"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin134"/>
       <skos:scopeNote xml:lang="en">A detachable flexible cover (usually paper) for a book.  Cf. Wrappers.</skos:scopeNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
@@ -1837,12 +1837,12 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin202">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin202">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Dutch gilt papers</skos:prefLabel>
       <skos:altLabel xml:lang="en">Dutch flowered papers</skos:altLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin179"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin179"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -1860,14 +1860,14 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin203">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin203">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Edge titles</skos:prefLabel>
       <skos:altLabel xml:lang="en">Fore-edge titles</skos:altLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin204"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin69"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin205"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin204"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin69"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin205"/>
       <skos:scopeNote xml:lang="en">The identification of the author, title, etc. of a book written on the edge of its block.</skos:scopeNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
@@ -1886,13 +1886,13 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin52">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin52">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Edges of binding boards</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin88"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin51"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin53"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin88"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin51"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin53"/>
       <skos:scopeNote xml:lang="en">Gathering term; do not use; index under a narrower term.</skos:scopeNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
@@ -1911,14 +1911,14 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin171">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin171">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Edges of text block</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin4"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin170"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin431"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin206"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin4"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin170"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin431"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin206"/>
       <skos:scopeNote xml:lang="en">Gathering term; do not use; index under a narrower term.</skos:scopeNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
@@ -1937,13 +1937,13 @@
          <dcterms:date>2015-04-21</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin208">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin208">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Embossed bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin16"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin209"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin210"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin16"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin209"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin210"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -1961,13 +1961,13 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin209">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin209">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Embossed cloth bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin208"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin145"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin211"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin208"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin145"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin211"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -1985,12 +1985,12 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin179">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin179">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Embossed paper bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin108"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin202"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin108"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin202"/>
       <skos:historyNote xml:lang="en">Changed 6/2016. Formerly, "Embossed paper bindings" may have been indexed as "Embossed papers."</skos:historyNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
@@ -2014,12 +2014,12 @@
          <dcterms:date>2000-01-01</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin141">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin141">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Embroidered bindings</skos:prefLabel>
       <skos:altLabel xml:lang="en">Needlework bindings</skos:altLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin104"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin104"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -2037,12 +2037,12 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin213">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin213">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Enamel bindings</skos:prefLabel>
       <skos:altLabel xml:lang="en">Limoges work bindings</skos:altLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin215"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin215"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -2060,11 +2060,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin139">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin139">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Enamel clasps</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin85"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin85"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -2082,13 +2082,13 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin25">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin25">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Endpapers</skos:prefLabel>
       <skos:altLabel xml:lang="en">Lining papers</skos:altLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin23"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin28"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin23"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin28"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -2106,11 +2106,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin218">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin218">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Engraved paper binding labels</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin219"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin219"/>
       <skos:historyNote xml:lang="en">Changed 6/2016. Formerly, "Engraved paper binding labels" may have been indexed as "Engraved paper labels."</skos:historyNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
@@ -2134,12 +2134,12 @@
          <dcterms:date>2000-01-01</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin66">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin66">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Errors (Gathering term; do not assign)</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin64"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin67"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin64"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin67"/>
       <skos:scopeNote xml:lang="en">Gathering term; do not use; index under a narrower term.</skos:scopeNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
@@ -2163,11 +2163,11 @@
          <dcterms:date>2000-01-01</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin221">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin221">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Etruscan bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin14"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin14"/>
       <skos:scopeNote xml:lang="en">An English binding style used from the 1770s through the first few decades of the nineteenth century.  Characterized by an outer border of palmettes created by acid staining, and a central panel which is usually tree calf.</skos:scopeNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
@@ -2186,11 +2186,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin47">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin47">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">False bands</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin44"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin44"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -2208,12 +2208,12 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin223">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin223">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Fan style bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin14"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin224"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin14"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin224"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -2231,11 +2231,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin225">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin225">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Fanfare bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin14"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin14"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -2253,15 +2253,15 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin82">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin82">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Fastenings, Attachments, or Titling (Gathering term; do not assign)</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin81"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin131"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin96"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin436"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin204"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin81"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin131"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin96"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin436"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin204"/>
       <skos:scopeNote xml:lang="en">Gathering term; do not use; index under a narrower term.</skos:scopeNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
@@ -2285,11 +2285,11 @@
          <dcterms:date>2000-01-01</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin226">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin226">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Filigree</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin16"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin16"/>
       <skos:scopeNote xml:lang="en">Decorative work using fine wires, usually gold or silver.  Use for filigree occurring anywhere on bindings or casings.</skos:scopeNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
@@ -2308,14 +2308,14 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin227">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin227">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Fillet tools</skos:prefLabel>
       <skos:altLabel xml:lang="en">Roulette tools</skos:altLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin229"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin230"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin231"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin229"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin230"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin231"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -2333,17 +2333,17 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin136">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin136">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Flap bindings</skos:prefLabel>
       <skos:altLabel xml:lang="en">Envelope flaps</skos:altLabel>
       <skos:altLabel xml:lang="en">Flaps</skos:altLabel>
       <skos:altLabel xml:lang="en">Wallet edges</skos:altLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin7"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin135"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin235"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin137"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin7"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin135"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin235"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin137"/>
       <skos:scopeNote xml:lang="en">Use for bindings which include or employ flaps.</skos:scopeNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
@@ -2362,11 +2362,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin180">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin180">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Flock paper bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin108"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin108"/>
       <skos:historyNote xml:lang="en">Changed 6/2016. Formerly, "Flock paper bindings" may have been indexed as "Flocked papers."</skos:historyNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
@@ -2390,13 +2390,13 @@
          <dcterms:date>2000-01-01</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin67">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin67">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Folding errors</skos:prefLabel>
       <skos:altLabel xml:lang="en">Errors in folding</skos:altLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin66"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin64"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin66"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin64"/>
       <skos:scopeNote xml:lang="en">For errors in folding one or more sheets of text.</skos:scopeNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
@@ -2415,12 +2415,12 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin194">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin194">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Fore-edge paintings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin175"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin193"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin175"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin193"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -2438,14 +2438,14 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin17">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin17">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Fur bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin16"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin15"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin18"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin19"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin16"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin15"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin18"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin19"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -2463,17 +2463,17 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin96">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin96">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Furniture</skos:prefLabel>
       <skos:altLabel xml:lang="en">Metal furniture</skos:altLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin82"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin95"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin129"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin130"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin242"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin131"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin82"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin95"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin129"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin130"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin242"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin131"/>
       <skos:scopeNote xml:lang="en">Metal attachments to one or both covers.  Their function is to protect the binding.</skos:scopeNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
@@ -2492,13 +2492,13 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin173">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin173">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Gauffered edges</skos:prefLabel>
       <skos:altLabel xml:lang="en">Goffered edges</skos:altLabel>
       <skos:altLabel xml:lang="en">Tooled edges</skos:altLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin170"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin170"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -2516,15 +2516,15 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin248">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin248">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Geometric tools</skos:prefLabel>
       <skos:altLabel xml:lang="en">Geometric rolls</skos:altLabel>
       <skos:altLabel xml:lang="en">Geometric stamps</skos:altLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin229"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin250"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin251"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin229"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin250"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin251"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -2542,11 +2542,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin253">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin253">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Gilt edges</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin170"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin170"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -2564,11 +2564,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin256">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin256">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Girdle books</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin7"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin7"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -2586,12 +2586,12 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin258">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin258">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Goatskin bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin18"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin259"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin18"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin259"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -2609,12 +2609,12 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin80">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin80">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Gold blocked bindings</skos:prefLabel>
       <skos:altLabel xml:lang="en">Gilt blocked bindings</skos:altLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin79"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin79"/>
       <skos:scopeNote xml:lang="en">Bindings with a design impressed by a block through gold.</skos:scopeNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
@@ -2633,11 +2633,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin260">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin260">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Gold powdered bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin16"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin16"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -2655,15 +2655,15 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin74">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin74">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Gold tooled bindings</skos:prefLabel>
       <skos:altLabel xml:lang="en">Gold stamped bindings</skos:altLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin73"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin71"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin75"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin76"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin73"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin71"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin75"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin76"/>
       <skos:note xml:lang="en">"Gold tooling--the bonding of gold leaf to leather by means of heated stamps."--Needham</skos:note>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
@@ -2682,13 +2682,13 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin230">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin230">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Gouge tools</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin229"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin227"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin231"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin229"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin227"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin231"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -2706,11 +2706,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin174">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin174">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Graphite edges</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin170"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin170"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -2728,11 +2728,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin262">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin262">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Greek style bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin14"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin14"/>
       <skos:note xml:lang="en">"Points of this fashion include the use of wooden boards, with grooved edges; smooth backs, with no bands showing through; raised headcaps at top and bottom of the back, containing a double row of sewn headbands; edges of the leaves cut flush with the boards; clasps made of braided leather, catching on pins protruding from the edge of the boards of the upper covers."--Needham.</skos:note>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
@@ -2751,11 +2751,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin263">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin263">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Grotesque bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin14"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin14"/>
       <skos:scopeNote xml:lang="en">16th century; decorated with grotesque figures, usually classical.</skos:scopeNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
@@ -2774,12 +2774,12 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin264">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin264">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Guard books</skos:prefLabel>
       <skos:altLabel xml:lang="en">Stub books</skos:altLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin7"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin7"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -2797,12 +2797,12 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin266">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin266">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Guards</skos:prefLabel>
       <skos:altLabel xml:lang="en">Sewing strips</skos:altLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin45"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin45"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -2820,13 +2820,13 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin268">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin268">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Half bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin16"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin269"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin270"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin16"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin269"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin270"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -2844,14 +2844,14 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin42">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin42">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Hatched tools</skos:prefLabel>
       <skos:altLabel xml:lang="en">Azured tools</skos:altLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin229"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin271"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin272"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin229"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin271"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin272"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -2869,14 +2869,14 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin26">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin26">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Headbands</skos:prefLabel>
       <skos:altLabel xml:lang="en">Endbands</skos:altLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin23"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin273"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin113"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin23"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin273"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin113"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -2894,11 +2894,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin274">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin274">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Headcaps</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin275"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin275"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -2916,11 +2916,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin89">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin89">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Hemp boards</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin88"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin88"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -2938,11 +2938,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin276">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin276">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Hollis bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin34"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin34"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -2960,12 +2960,12 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin277">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin277">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Hollow backs</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin275"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin278"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin275"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin278"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -2983,12 +2983,12 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin279">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin279">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Inlays</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin16"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin280"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin16"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin280"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -3006,12 +3006,12 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin281">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin281">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Interlace bindings</skos:prefLabel>
       <skos:altLabel xml:lang="en">Strapwork bindings</skos:altLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin14"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin14"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -3029,11 +3029,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/425">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/425">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Interleaved books</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin4"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin4"/>
       <skos:scopeNote xml:lang="en">Use for books bound with blank leaves systematically inserted between the original leaves, whether by the publisher or owner, to facilitate user-added content.</skos:scopeNote>
       <skos:historyNote xml:lang="en">Added 12/2011.</skos:historyNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
@@ -3053,11 +3053,11 @@
          <dcterms:date>2012-05-30</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin283">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin283">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Iron clasps</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin101"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin101"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -3075,12 +3075,12 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin284">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin284">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Islamic bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin14"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin285"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin14"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin285"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -3098,11 +3098,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin286">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin286">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Ivory bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin215"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin215"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -3120,11 +3120,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin287">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin287">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Jansenist style bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin14"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin14"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -3142,11 +3142,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin288">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin288">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Japanese sewing</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin289"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin289"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -3164,12 +3164,12 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin246">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin246">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Jewelled bindings</skos:prefLabel>
       <skos:altLabel xml:lang="en">Gem bindings</skos:altLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin215"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin215"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -3187,11 +3187,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin290">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin290">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Kangaroo leather bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin18"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin18"/>
       <skos:historyNote xml:lang="en">Term added 2/97.</skos:historyNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
@@ -3210,11 +3210,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin291">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin291">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Kermes dyed bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin16"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin16"/>
       <skos:scopeNote xml:lang="en">Bindings dyed by means of Kermes (a red dyestuff obtained from a Mediterranean scale insect).  Kermes was largely supplanted by cochineal as a dyestuff after the latter's introduction into Europe in the 16th and 17th centuries.</skos:scopeNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
@@ -3233,12 +3233,12 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin142">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin142">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Lace bindings (Materials)</skos:prefLabel>
       <skos:altLabel xml:lang="en">Needlework bindings</skos:altLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin104"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin104"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -3256,12 +3256,12 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin294">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin294">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Lacquered bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin16"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin295"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin16"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin295"/>
       <skos:scopeNote xml:lang="en">Bindings with scenes on their covers which are first painted and then covered with lacquer.  Primarily 16th century; the painted scenes can be on leather or pasteboard.</skos:scopeNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
@@ -3280,11 +3280,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin296">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin296">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Lambskin bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin297"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin297"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -3302,11 +3302,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin298">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin298">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Landscape bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin14"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin14"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -3324,11 +3324,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin299">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin299">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Law bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin14"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin14"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -3346,29 +3346,29 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin18">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin18">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Leather bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin16"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin114"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin165"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin106"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin191"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin258"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin290"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin164"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin302"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin303"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin210"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin377"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin304"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin305"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin306"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin297"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin15"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin17"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin19"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin16"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin114"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin165"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin106"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin191"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin258"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin290"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin164"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin302"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin303"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin210"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin377"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin304"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin305"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin306"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin297"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin15"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin17"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin19"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -3386,13 +3386,13 @@
          <dcterms:date>2007-08-03</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin195">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin195">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Leather doublures</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin24"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin307"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin308"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin24"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin307"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin308"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -3410,11 +3410,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin310">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin310">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Leather thongs</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin21"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin21"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -3432,11 +3432,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin311">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin311">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Ledger bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin14"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin14"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -3454,14 +3454,14 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin293">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin293">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Lettering pieces</skos:prefLabel>
       <skos:altLabel xml:lang="en">Leather labels</skos:altLabel>
       <skos:altLabel xml:lang="en">Letter pieces</skos:altLabel>
       <skos:altLabel xml:lang="en">Skiver labels</skos:altLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin69"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin69"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -3479,12 +3479,12 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin315">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin315">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Limp bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin7"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin150"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin7"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin150"/>
       <skos:scopeNote xml:lang="en">Use for any kind of limp binding.</skos:scopeNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
@@ -3503,12 +3503,12 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin316">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin316">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Linings</skos:prefLabel>
       <skos:altLabel xml:lang="en">Spine linings</skos:altLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin275"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin275"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -3526,14 +3526,14 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin86">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin86">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Loop-and-ball fastenings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin81"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin83"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin85"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin87"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin81"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin83"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin85"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin87"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -3551,11 +3551,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin409">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin409">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Machine-made headbands</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin273"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin273"/>
       <skos:scopeNote xml:lang="en">Use for headbands woven by machine on cloth or other type of support, often in imitation of worked headbands.</skos:scopeNote>
       <skos:historyNote xml:lang="en">Approved 6/2005.</skos:historyNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
@@ -3575,11 +3575,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin320">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin320">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Manuscript waste</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin321"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin321"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -3597,13 +3597,13 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin322">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin322">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Marbled calf bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin114"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin319"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin323"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin114"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin319"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin323"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -3621,11 +3621,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin324">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin324">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Marbled edges</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin177"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin177"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -3643,11 +3643,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin181">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin181">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Marbled paper bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin108"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin108"/>
       <skos:historyNote xml:lang="en">Changed 6/2016. Formerly, "Marbled paper bindings" may have been indexed as "Marbled papers."</skos:historyNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
@@ -3671,11 +3671,11 @@
          <dcterms:date>2000-01-01</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin406">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin406">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Marbled sheepskin bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin297"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin297"/>
       <skos:scopeNote xml:lang="en">Use for sheepsking bindings whose surface has been treated with acid to produce a marbled effect.</skos:scopeNote>
       <skos:historyNote xml:lang="en">Proposed by Rose-Ann Movsovic; term approved 1/2006</skos:historyNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
@@ -3695,12 +3695,12 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin326">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin326">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Maril</skos:prefLabel>
       <skos:altLabel xml:lang="en">Marbled inlaid leather</skos:altLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin16"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin16"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -3718,11 +3718,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin327">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin327">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Masonic bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin14"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin14"/>
       <skos:scopeNote xml:lang="en">Bindings decorated with Masonic motifs; primarily late 18th and early 19th centuries.</skos:scopeNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
@@ -3741,41 +3741,41 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin16">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin16">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Materials and treatment (Gathering term; do not assign)</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin15"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin22"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin104"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin108"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin208"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin226"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin17"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin260"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin268"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin279"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin291"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin294"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin18"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin326"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin280"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin295"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin159"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin328"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin329"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin330"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin269"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin73"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin270"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin331"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin169"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin215"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin410"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin19"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin405"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin321"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin332"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin15"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin22"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin104"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin108"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin208"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin226"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin17"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin260"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin268"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin279"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin291"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin294"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin18"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin326"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin280"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin295"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin159"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin328"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin329"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin330"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin269"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin73"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin270"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin331"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin169"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin215"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin410"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin19"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin405"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin321"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin332"/>
       <skos:scopeNote xml:lang="en">Gathering term; do not use; index under a narrower term.</skos:scopeNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
@@ -3799,12 +3799,12 @@
          <dcterms:date>2000-01-01</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin426">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin426">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Mauchline ware bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin332"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin91"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin332"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin91"/>
       <skos:scopeNote xml:lang="en">Use for novelty bindings decorated using a technique that originated in the 1830s in the Scottish town of Mauchline, in which wooden boards are decorated with stenciling, transfer prints, photographs, etc., then heavily varnished.</skos:scopeNote>
       <skos:historyNote xml:lang="en">Submitted by: Jennie Clements, UNC Chapel Hill, 9/9/11; added 6/26/2012.</skos:historyNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
@@ -3824,13 +3824,13 @@
          <dcterms:date>2012-06-26</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin418">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin418">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Mechanical bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin7"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin419"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin420"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin7"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin419"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin420"/>
       <skos:scopeNote xml:lang="en">Use for bindings in which a device of metal, plastic, etc., holds single leaves together in a non-exchangeable manner.</skos:scopeNote>
       <skos:historyNote xml:lang="en">Approved 6/2008.</skos:historyNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
@@ -3850,8 +3850,8 @@
          <dcterms:date>2008-07-11</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin111">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin111">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Medallion tools</skos:prefLabel>
       <skos:altLabel xml:lang="en">Bust rolls</skos:altLabel>
       <skos:altLabel xml:lang="en">Bust stamps</skos:altLabel>
@@ -3862,7 +3862,7 @@
       <skos:altLabel xml:lang="en">Portrait medallion rolls</skos:altLabel>
       <skos:altLabel xml:lang="en">Portrait medallion stamps</skos:altLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin229"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin229"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -3880,14 +3880,14 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin101">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin101">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Metal clasps</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin85"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin100"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin283"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin338"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin85"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin100"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin283"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin338"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -3905,11 +3905,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin339">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin339">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Middle Hill boards</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin34"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin34"/>
       <skos:scopeNote xml:lang="en">Found on books and manuscripts bound for Sir Thomas Phillipps' library at Middle Hill.  The usual style is a drab colored paper over millboard, without pastedowns or other endpapers.  The text block is sewn on two cords, which are laced through the boards.  Phillipps' shelf-mark is usually present in the form: [Roman numeral].[lowercase letter].[Arabic numeral].</skos:scopeNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
@@ -3928,11 +3928,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin196">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin196">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Moiré doublures</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin24"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin24"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -3950,14 +3950,14 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin164">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin164">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Molded leather bindings</skos:prefLabel>
       <skos:altLabel xml:lang="en">Cuir bouilli bindings</skos:altLabel>
       <skos:altLabel xml:lang="en">Sculptured leather bindings</skos:altLabel>
       <skos:altLabel xml:lang="en">Shaped leather bindings</skos:altLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin18"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin18"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -3975,13 +3975,13 @@
          <dcterms:date>2007-08-03</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin39">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin39">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Monogrammed bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin34"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin37"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin40"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin34"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin37"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin40"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -3999,12 +3999,12 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin259">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin259">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Morocco bindings</skos:prefLabel>
       <skos:altLabel xml:lang="en">Levant bindings</skos:altLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin258"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin258"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -4022,11 +4022,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin307">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin307">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Morocco doublures</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin195"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin195"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -4044,11 +4044,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin342">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin342">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Mosaic bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin14"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin14"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -4066,12 +4066,12 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin343">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin343">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Mottled calf bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin114"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin323"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin114"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin323"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -4089,12 +4089,12 @@
          <dcterms:date>2007-08-03</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin285">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin285">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Mudéjar bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin14"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin284"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin14"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin284"/>
       <skos:note xml:lang="en">A Spanish binding style, used in the 13th-15th centuries, "with Islamic decorative schemes: elaborate geometric interlace bands against a background entirely filled with hundreds of repetitions of small knotwork or cablework tools." -- Needham.</skos:note>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
@@ -4113,13 +4113,13 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin143">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin143">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Needlepoint bindings</skos:prefLabel>
       <skos:altLabel xml:lang="en">Needlework bindings</skos:altLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin104"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin344"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin104"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin344"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -4137,12 +4137,12 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin9">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin9">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Non-adhesive bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin7"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin5"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin7"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin5"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -4160,13 +4160,13 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin280">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin280">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Onlays</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin16"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin417"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin279"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin16"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin417"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin279"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -4184,13 +4184,13 @@
          <dcterms:date>2008-07-11</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin271">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin271">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Open tools</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin229"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin42"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin272"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin229"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin42"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin272"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -4208,13 +4208,13 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin121">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin121">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Original covers</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin119"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin120"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin124"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin119"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin120"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin124"/>
       <skos:scopeNote xml:lang="en">For examples of original covers as issued by the bookseller, publisher, etc.</skos:scopeNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
@@ -4233,11 +4233,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin302">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin302">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Ostrich leather bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin18"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin18"/>
       <skos:historyNote xml:lang="en">Term added 2/97.</skos:historyNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
@@ -4256,11 +4256,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin345">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin345">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Overcasting</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin289"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin289"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -4278,14 +4278,14 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin295">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin295">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Painted bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin16"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin346"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin347"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin294"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin16"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin346"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin347"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin294"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -4303,12 +4303,12 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin175">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin175">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Painted edges</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin170"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin194"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin170"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin194"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -4326,12 +4326,12 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin346">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin346">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Painted leather bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin295"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin323"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin295"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin323"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -4349,11 +4349,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin182">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin182">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Painted paper bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin108"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin108"/>
       <skos:historyNote xml:lang="en">Changed 6/2016. Formerly, "Painted paper bindings" may have been indexed as "Painted papers."</skos:historyNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
@@ -4377,13 +4377,13 @@
          <dcterms:date>2000-01-01</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin231">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin231">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Pallet tools</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin229"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin227"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin230"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin229"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin227"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin230"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -4401,13 +4401,13 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin413">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin413">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Panel-stamped bindings</skos:prefLabel>
       <skos:altLabel xml:lang="en">Panel stamp bindings</skos:altLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin73"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin79"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin73"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin79"/>
       <skos:scopeNote xml:lang="en">Use for leather bindings with designs in relief from the impression of intaglio dies, produced predominantly in the 15th and 16th centuries.</skos:scopeNote>
       <skos:historyNote xml:lang="en">Approved 6/2007. Disambiguated from "blocked bindings" based on literary warant.</skos:historyNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
@@ -4427,13 +4427,13 @@
          <dcterms:date>2007-06-28</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin219">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin219">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Paper binding labels</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin69"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin218"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin349"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin69"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin218"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin349"/>
       <skos:historyNote xml:lang="en">Changed 6/2016. Formerly, "Paper binding labels" may have been indexed as "Paper labels."</skos:historyNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
@@ -4457,13 +4457,13 @@
          <dcterms:date>2000-01-01</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin159">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin159">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Paper bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin16"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin156"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin348"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin16"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin156"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin348"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -4481,11 +4481,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin417">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin417">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Paper onlays</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin280"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin280"/>
       <skos:scopeNote xml:lang="en">Use for decorative pieces of paper adhered to the cover material of a binding, frequently color-printed and employed in the decoration of publishers' cloth bindings</skos:scopeNote>
       <skos:historyNote xml:lang="en">Approved 6/2008.</skos:historyNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
@@ -4505,11 +4505,11 @@
          <dcterms:date>2008-07-11</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin328">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin328">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Papier-mâché bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin16"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin16"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -4527,11 +4527,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin176">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin176">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Paste edges</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin170"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin170"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -4549,11 +4549,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin183">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin183">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Paste paper bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin108"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin108"/>
       <skos:historyNote xml:lang="en">Changed 6/2016. Formerly, "Paste paper bindings" may have been indexed as "Paste papers."</skos:historyNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
@@ -4577,11 +4577,11 @@
          <dcterms:date>2000-01-01</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin90">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin90">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Pasteboard</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin88"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin88"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -4599,12 +4599,12 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin353">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin353">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Penitential bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin14"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin354"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin14"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin354"/>
       <skos:note xml:lang="en">"A number of later sixteenth-century Parisian 'penitential' bindings are tooled in silver on dark brown morocco to create a somber appearance." -- Needham</skos:note>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
@@ -4623,11 +4623,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin344">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin344">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Petit point bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin143"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin143"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -4645,11 +4645,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin355">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin355">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Pictorial bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin14"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin14"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -4667,12 +4667,12 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin329">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin329">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Pictorial cloth bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin16"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin145"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin16"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin145"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -4690,12 +4690,12 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin303">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin303">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Pigskin bindings</skos:prefLabel>
       <skos:altLabel xml:lang="en">Peccary bindings</skos:altLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin18"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin18"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -4713,12 +4713,12 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin358">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin358">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Pinhead style bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin73"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin240"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin73"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin240"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -4736,12 +4736,12 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin99">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin99">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Plaited headbands</skos:prefLabel>
       <skos:altLabel xml:lang="en">Braided headbands</skos:altLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin113"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin113"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -4759,11 +4759,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin359">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin359">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Plaquette stamps</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin229"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin229"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -4781,15 +4781,15 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin75">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin75">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Platinum tooled bindings</skos:prefLabel>
       <skos:altLabel xml:lang="en">Platina tooled bindings</skos:altLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin73"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin71"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin74"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin76"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin73"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin71"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin74"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin76"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -4807,13 +4807,13 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin240">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin240">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Pointillé tooling</skos:prefLabel>
       <skos:altLabel xml:lang="en">French pointillé tooling</skos:altLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin73"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin358"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin73"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin358"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -4831,13 +4831,13 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin361">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin361">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Pre-ornamented cloth bindings</skos:prefLabel>
       <skos:altLabel xml:lang="en">Pre-ornamented bookcloth bindings</skos:altLabel>
       <skos:altLabel xml:lang="en">Preornamented cloth bindings</skos:altLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin145"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin145"/>
       <skos:scopeNote xml:lang="en">Use for cloth bindings produced ca. 1835-1846, characterized by a central ornament in which the cloth was ornamented before the case was made, as described by Krupp &amp; Rosner, "Pre-Ornamented Bookcloth on Nineteenth-Century Cloth Bindings," PBSA 94:2.</skos:scopeNote>
       <skos:historyNote xml:lang="en">Term added 01/01.</skos:historyNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
@@ -4857,11 +4857,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin122">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin122">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Presentation bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin119"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin119"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -4879,12 +4879,12 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin330">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin330">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Printed boards</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin16"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin124"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin16"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin124"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -4902,11 +4902,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin349">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin349">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Printed paper binding labels</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin219"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin219"/>
       <skos:historyNote xml:lang="en">Changed 6/2016. Formerly, "Printed paper binding labels" may have been indexed as "Printed paper labels."</skos:historyNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
@@ -4930,12 +4930,12 @@
          <dcterms:date>2000-01-01</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin184">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin184">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Printed paper bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin108"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin78"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin108"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin78"/>
       <skos:historyNote xml:lang="en">Changed 6/2016. Formerly, "Printed paper bindings" may have been indexed as "Printed papers."</skos:historyNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
@@ -4959,11 +4959,11 @@
          <dcterms:date>2000-01-01</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin364">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin364">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Printed waste</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin321"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin321"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -4981,13 +4981,13 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin357">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin357">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Printed wrappers</skos:prefLabel>
       <skos:altLabel xml:lang="en">Pictorial paper wrappers</skos:altLabel>
       <skos:altLabel xml:lang="en">Printed paper wrappers</skos:altLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin150"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin150"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -5005,11 +5005,11 @@
          <dcterms:date>2007-08-03</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin123">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin123">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Prize bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin119"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin119"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -5027,19 +5027,19 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin34">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin34">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Proprietary bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin119"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin32"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin37"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin162"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin276"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin339"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin39"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin40"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin365"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin119"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin32"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin37"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin162"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin276"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin339"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin39"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin40"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin365"/>
       <skos:scopeNote xml:lang="en">Gathering term; do not use; index under a narrower term.</skos:scopeNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
@@ -5058,14 +5058,14 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin134">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin134">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Protective housing (Gathering term; do not assign)</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin133"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin427"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin93"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin411"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin133"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin427"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin93"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin411"/>
       <skos:scopeNote xml:lang="en">Gathering term; do not use; index under a narrower term.</skos:scopeNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
@@ -5089,16 +5089,16 @@
          <dcterms:date>2000-01-01</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin124">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin124">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Publishers' bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin119"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin330"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin145"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin348"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin120"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin121"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin119"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin330"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin145"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin348"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin120"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin121"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -5116,15 +5116,15 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin145">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin145">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Publishers' cloth bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin124"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin209"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin329"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin361"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin104"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin124"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin209"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin329"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin361"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin104"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -5142,12 +5142,12 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin348">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin348">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Publishers' paper bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin124"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin159"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin124"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin159"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -5165,11 +5165,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin366">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin366">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Punch-dotting</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin73"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin73"/>
       <skos:note xml:lang="en">"A type of decoration of Islamic origin in which small punched depressions in the leather are filled with a kind of colored gesso." -- Needham</skos:note>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
@@ -5188,13 +5188,13 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin269">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin269">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Quarter bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin16"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin268"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin270"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin16"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin268"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin270"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -5212,11 +5212,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin48">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin48">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Raised bands</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin44"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin44"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -5234,11 +5234,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin153">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin153">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Raised cords</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin49"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin49"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -5256,11 +5256,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin367">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin367">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Rebacking</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin368"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin368"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -5278,11 +5278,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin369">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin369">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Recasing</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin368"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin368"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -5300,12 +5300,12 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin154">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin154">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Recessed cords</skos:prefLabel>
       <skos:altLabel xml:lang="en">Sawn-in cords</skos:altLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin49"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin49"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -5323,15 +5323,15 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin210">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin210">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Relievo bindings</skos:prefLabel>
       <skos:altLabel xml:lang="en">Leak's patent relievo leather bindings</skos:altLabel>
       <skos:altLabel xml:lang="en">Leak's relievo leather bindings</skos:altLabel>
       <skos:altLabel xml:lang="en">Relievo leather bindings</skos:altLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin208"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin18"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin208"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin18"/>
       <skos:scopeNote xml:lang="en">Use for bindings of deeply embossed leather executed in Leake's patent relievo process (1846-1850s).</skos:scopeNote>
       <skos:historyNote xml:lang="en">Term added 01/01.</skos:historyNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
@@ -5351,11 +5351,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin374">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin374">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Remboîtage</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin368"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin368"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -5373,11 +5373,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin376">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin376">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Resewing</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin368"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin368"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -5395,12 +5395,12 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin31">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin31">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Retrospective bindings</skos:prefLabel>
       <skos:altLabel xml:lang="en">Antique bindings</skos:altLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin14"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin14"/>
       <skos:scopeNote xml:lang="en">A conscious imitation of an earlier style.</skos:scopeNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
@@ -5419,11 +5419,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin377">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin377">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Reversed leather bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin18"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin18"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -5441,11 +5441,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin211">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin211">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Ribbon-embossed cloth bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin209"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin209"/>
       <skos:scopeNote xml:lang="en">Use for cloth bindings embossed by machines used to emboss ribbons, thereby giving the bindings a raised, often floral pattern.</skos:scopeNote>
       <skos:historyNote xml:lang="en">Term added 7/00.</skos:historyNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
@@ -5465,14 +5465,14 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin436">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin436">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Ribbon markers</skos:prefLabel>
       <skos:altLabel xml:lang="en">Finding ribbon</skos:altLabel>
       <skos:altLabel xml:lang="en">Registers (place markers)</skos:altLabel>
       <skos:altLabel xml:lang="en">Signets</skos:altLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin82"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin82"/>
       <skos:scopeNote xml:lang="en">Use for ribbons attached at the head of the spine to be used as a place marker in the book. For unattached devices intended to be inserted between leaves in a book as a place marker, use Bookmarks.</skos:scopeNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
@@ -5491,12 +5491,12 @@
          <dcterms:date>2015-04-21</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin378">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin378">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Roan bindings</skos:prefLabel>
       <skos:altLabel xml:lang="en">Split sheepskin bindings</skos:altLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin297"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin297"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -5514,13 +5514,13 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin40">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin40">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Royal bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin34"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin37"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin39"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin34"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin37"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin39"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -5538,12 +5538,12 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin372">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin372">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Ruling in red</skos:prefLabel>
       <skos:altLabel xml:lang="en">Red ruling</skos:altLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin4"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin4"/>
       <skos:scopeNote xml:lang="en">Manuscript ruling in red ink in order to set off the text.</skos:scopeNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
@@ -5562,12 +5562,12 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin304">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin304">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Russia leather bindings</skos:prefLabel>
       <skos:altLabel xml:lang="en">Russia calf bindings</skos:altLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin18"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin18"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -5585,11 +5585,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin381">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin381">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Scaleboard</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin91"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin91"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -5607,12 +5607,12 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin382">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin382">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Scottish herringbone design bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin14"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin224"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin14"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin224"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -5630,12 +5630,12 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin224">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin224">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Scottish wheel design bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin223"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin382"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin223"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin382"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -5653,13 +5653,13 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin305">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin305">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Sealskin bindings</skos:prefLabel>
       <skos:altLabel xml:lang="en">Seal-skin bindings</skos:altLabel>
       <skos:altLabel xml:lang="en">Seal skin bindings</skos:altLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin18"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin18"/>
       <skos:historyNote xml:lang="en">Term added 6/02.</skos:historyNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
@@ -5678,11 +5678,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin385">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin385">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Semé</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin73"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin73"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -5700,11 +5700,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin365">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin365">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Settle bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin34"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin34"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -5722,15 +5722,15 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin11">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin11">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Sewing patterns</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin4"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin10"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin386"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin12"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin289"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin4"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin10"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin386"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin12"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin289"/>
       <skos:scopeNote xml:lang="en">Gathering term; do not use; index under a narrower term.</skos:scopeNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
@@ -5749,11 +5749,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin306">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin306">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Shagreen bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin18"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin18"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -5771,15 +5771,15 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin297">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin297">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Sheepskin bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin18"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin296"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin406"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin378"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin397"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin18"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin296"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin406"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin378"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin397"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -5797,12 +5797,12 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin60">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin60">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Signed bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin56"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin59"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin56"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin59"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -5820,11 +5820,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin197">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin197">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Silk doublures</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin24"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin24"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -5842,11 +5842,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin387">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin387">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Silk ties</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin87"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin87"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -5864,13 +5864,13 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin255">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin255">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Silver bindings</skos:prefLabel>
       <skos:altLabel xml:lang="en">Gilt silver bindings</skos:altLabel>
       <skos:altLabel xml:lang="en">Repoussé silver bindings</skos:altLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin215"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin215"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -5888,13 +5888,13 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin126">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin126">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Silver catches</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin83"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin138"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin338"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin83"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin138"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin338"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -5912,13 +5912,13 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin138">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin138">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Silver clasp plates</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin84"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin126"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin338"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin84"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin126"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin338"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -5936,13 +5936,13 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin338">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin338">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Silver clasps</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin101"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin126"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin138"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin101"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin126"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin138"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -5960,11 +5960,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin242">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin242">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Silver furniture</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin96"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin96"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -5982,14 +5982,14 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin76">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin76">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Silver tooled bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin73"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin71"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin74"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin75"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin73"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin71"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin74"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin75"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -6007,12 +6007,12 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin411">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin411">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Slipcases</skos:prefLabel>
       <skos:altLabel xml:lang="en">Slip cases</skos:altLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin134"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin134"/>
       <skos:scopeNote xml:lang="en">Use for protective containers open along one edge.</skos:scopeNote>
       <skos:historyNote xml:lang="en">Term added 6/06. Proposed by Nina Schneider.</skos:historyNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
@@ -6032,12 +6032,12 @@
          <dcterms:date>2007-01-08</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin237">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin237">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Smooth spines</skos:prefLabel>
       <skos:altLabel xml:lang="en">Flat spines</skos:altLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin275"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin275"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -6055,13 +6055,13 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin272">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin272">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Solid tools</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin229"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin42"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin271"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin229"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin42"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin271"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -6079,12 +6079,12 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin354">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin354">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Somber bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin14"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin353"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin14"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin353"/>
       <skos:note xml:lang="en">"'Somber' bindings of silver-tooled black morocco were common in Restoration England." -- Needham.</skos:note>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
@@ -6103,15 +6103,15 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin275">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin275">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Spines (Gathering term; do not assign)</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin274"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin277"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin316"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin237"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin278"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin274"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin277"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin316"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin237"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin278"/>
       <skos:scopeNote xml:lang="en">Gathering term; do not use; index under a narrower term.</skos:scopeNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
@@ -6130,13 +6130,13 @@
          <dcterms:date>2007-08-03</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin420">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin420">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Spiral bindings</skos:prefLabel>
       <skos:altLabel xml:lang="en">Coil bindings</skos:altLabel>
       <skos:altLabel xml:lang="en">Spirex bindings</skos:altLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin418"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin418"/>
       <skos:scopeNote xml:lang="en">Use for bindings in which a coil of metal, plastic, etc., passes through a series of holes in a margin of the text block.</skos:scopeNote>
       <skos:historyNote xml:lang="en">Approved 6/2008.</skos:historyNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
@@ -6156,12 +6156,12 @@
          <dcterms:date>2008-07-11</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin388">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin388">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Sprinkled calf bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin114"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin323"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin114"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin323"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -6179,11 +6179,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin389">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin389">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Sprinkled edges</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin177"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin177"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -6201,11 +6201,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin185">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin185">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Sprinkled paper bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin108"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin108"/>
       <skos:historyNote xml:lang="en">Changed 6/2016. Formerly, "Sprinkled paper bindings" may have been indexed as "Sprinkled papers."</skos:historyNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
@@ -6229,12 +6229,12 @@
          <dcterms:date>2000-01-01</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin53">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin53">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Square edge boards</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin52"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin51"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin52"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin51"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -6252,11 +6252,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin386">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin386">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Stabbing</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin11"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin11"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -6274,15 +6274,15 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin323">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin323">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Stained calf bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin114"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin322"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin343"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin346"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin388"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin114"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin322"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin343"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin346"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin388"/>
       <skos:scopeNote xml:lang="en">Use for leather stained in ways other than by marbling, mottling, or sprinkling.  This includes staining by means of blocking, stencilling, or free-hand design.</skos:scopeNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
@@ -6301,13 +6301,13 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin177">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin177">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Stained edges</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin170"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin324"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin389"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin170"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin324"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin389"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -6325,11 +6325,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin390">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin390">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Stained vellum bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin19"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin19"/>
       <skos:scopeNote xml:lang="en">Use for vellum bindings that have been colored by the application of a dilute colored liquid, a process that results in a transparent color that penetrates the material, allowing the underlying texture of the skin to be visible.</skos:scopeNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
@@ -6348,22 +6348,22 @@
          <dcterms:date>2016-02-02</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin73">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin73">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Stamped or tooled bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin16"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin71"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin79"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin74"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin413"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin358"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin75"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin240"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin366"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin385"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin76"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin229"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin16"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin71"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin79"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin74"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin413"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin358"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin75"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin240"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin366"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin385"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin76"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin229"/>
       <skos:scopeNote xml:lang="en">Gathering term; do not use; index under a narrower term.</skos:scopeNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
@@ -6382,11 +6382,11 @@
          <dcterms:date>2007-06-28</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin186">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin186">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Stamped paper bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin108"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin108"/>
       <skos:historyNote xml:lang="en">Changed 6/2016. Formerly, "Stamped paper bindings" may have been indexed as "Stamped papers."</skos:historyNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
@@ -6410,11 +6410,11 @@
          <dcterms:date>2000-01-01</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin187">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin187">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Stencilled paper bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin108"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin108"/>
       <skos:historyNote xml:lang="en">Changed 6/2016. Formerly, "Stencilled paper bindings" may have been indexed as "Stencilled papers."</skos:historyNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
@@ -6438,13 +6438,13 @@
          <dcterms:date>2000-01-01</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin273">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin273">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Stuck-on headbands</skos:prefLabel>
       <skos:altLabel xml:lang="en">Glued-on headbands</skos:altLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin26"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin409"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin26"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin409"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -6462,40 +6462,40 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin14">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin14">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Styles (Gathering term; do not assign)</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin13"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin35"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin423"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin36"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin127"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin128"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin151"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin155"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin160"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin161"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin190"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin221"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin223"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin225"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin262"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin263"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin281"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin284"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin287"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin298"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin299"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin311"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin327"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin342"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin285"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin353"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin355"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin31"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin382"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin354"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin13"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin35"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin423"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin36"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin127"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin128"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin151"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin155"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin160"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin161"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin190"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin221"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin223"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin225"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin262"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin263"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin281"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin284"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin287"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin298"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin299"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin311"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin327"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin342"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin285"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin353"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin355"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin31"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin382"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin354"/>
       <skos:scopeNote xml:lang="en">Gathering term; do not use; index under a narrower term.</skos:scopeNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
@@ -6519,15 +6519,15 @@
          <dcterms:date>2000-01-01</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin368">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin368">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Subsequent treatment</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin367"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin369"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin374"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin376"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin391"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin367"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin369"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin374"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin376"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin391"/>
       <skos:scopeNote xml:lang="en">Gathering term; do not use; index under a narrower term.</skos:scopeNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
@@ -6546,11 +6546,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin308">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin308">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Suede doublures</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin195"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin195"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -6568,15 +6568,15 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin45">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin45">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Supports (Gathering term; do not assign)</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin44"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin49"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin266"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin50"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin21"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin44"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin49"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin266"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin50"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin21"/>
       <skos:scopeNote xml:lang="en">Gathering term; do not use; index under a narrower term.</skos:scopeNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
@@ -6600,12 +6600,12 @@
          <dcterms:date>2000-01-01</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin407">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin407">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Tacketed bindings</skos:prefLabel>
       <skos:altLabel xml:lang="en">Tacket bindings</skos:altLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin7"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin7"/>
       <skos:scopeNote xml:lang="en">Use for bindings in which the case is attached to the text block by means tackets, such as strips of parchment or leather thongs.</skos:scopeNote>
       <skos:historyNote xml:lang="en">Approved 6/2005</skos:historyNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
@@ -6625,12 +6625,12 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin392">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin392">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Tall copies</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin4"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin206"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin4"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin206"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -6648,16 +6648,16 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin50">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin50">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Tapes</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin45"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin147"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin393"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin44"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin49"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin21"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin45"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin147"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin393"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin44"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin49"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin21"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -6675,18 +6675,18 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin4">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin4">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Text block (Gathering term; do not assign)</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin1"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin171"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/425"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin372"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin11"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin392"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin394"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin399"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin1"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin171"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/425"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin372"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin11"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin392"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin394"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin399"/>
       <skos:scopeNote xml:lang="en">Gathering term; do not use; index under a narrower term.</skos:scopeNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
@@ -6710,17 +6710,17 @@
          <dcterms:date>2000-01-01</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin21">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin21">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Thongs</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin45"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin20"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin310"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin395"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin44"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin49"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin50"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin45"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin20"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin310"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin395"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin44"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin49"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin50"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -6738,13 +6738,13 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin270">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin270">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Three-quarter bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin16"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin268"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin269"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin16"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin268"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin269"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -6762,15 +6762,15 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin431">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin431">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Thumb indexes</skos:prefLabel>
       <skos:altLabel xml:lang="en">Cut-in indexes</skos:altLabel>
       <skos:altLabel xml:lang="en">Gouge indexes</skos:altLabel>
       <skos:altLabel xml:lang="en">Indexes, thumb</skos:altLabel>
       <skos:altLabel xml:lang="en">Thumb cuts</skos:altLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin171"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin171"/>
       <skos:scopeNote xml:lang="en">Use for cut-outs on the fore-edge of a book intended for locating sections within the volume, especially common on dictionaries and Bibles.</skos:scopeNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
@@ -6789,16 +6789,16 @@
          <dcterms:date>2015-04-21</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin87">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin87">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Ties</skos:prefLabel>
       <skos:altLabel xml:lang="en">Fabric ties</skos:altLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin81"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin387"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin83"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin85"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin86"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin81"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin387"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin83"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin85"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin86"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -6816,12 +6816,12 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin278">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin278">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Tight backs</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin275"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin277"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin275"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin277"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -6839,14 +6839,14 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin204">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin204">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Titling</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin82"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin69"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin203"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin205"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin82"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin69"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin203"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin205"/>
       <skos:scopeNote xml:lang="en">Gathering term; do not use; index under a narrower term.</skos:scopeNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
@@ -6865,11 +6865,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin198">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin198">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Tooled doublures</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin24"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin24"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -6887,14 +6887,14 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin205">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin205">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Tooled lettering</skos:prefLabel>
       <skos:altLabel xml:lang="en">Tooled titles</skos:altLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin204"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin69"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin203"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin204"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin69"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin203"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -6912,11 +6912,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin331">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin331">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Tortoise shell bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin16"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin16"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -6934,12 +6934,12 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin169">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin169">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Tracery</skos:prefLabel>
       <skos:altLabel xml:lang="en">Cutout leatherwork</skos:altLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin16"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin16"/>
       <skos:note xml:lang="en">"Cutout leatherwork, or tracery, was never a common technique in European bookbinding, but examples are known from the fifteenth and sixteenth centuries ... Several of the earliest European gold-tooled bookbindings, from both Venice and Naples, have leather tracery decoration, which was brought out, as in the Islamic archetypes, by being laid over a bright azure ground." -- Needham.</skos:note>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
@@ -6958,16 +6958,16 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin215">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin215">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Treasure bindings</skos:prefLabel>
       <skos:altLabel xml:lang="en">Medieval treasure bindings</skos:altLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin16"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin213"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin286"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin246"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin255"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin16"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin213"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin286"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin246"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin255"/>
       <skos:note xml:lang="en">"Covered with gold and silver, ivories, enamelwork, and gems." -- Needham.</skos:note>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
@@ -6986,13 +6986,13 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin319">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin319">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Tree calf bindings</skos:prefLabel>
       <skos:altLabel xml:lang="en">Mahogany marbled calf bindings</skos:altLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin322"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin397"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin322"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin397"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -7010,12 +7010,12 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin397">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin397">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Tree sheep bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin297"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin319"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin297"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin319"/>
       <skos:note xml:lang="en">In case of doubt use Tree calf bindings.</skos:note>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
@@ -7034,12 +7034,12 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin235">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin235">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Tucks</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin7"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin136"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin7"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin136"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -7057,11 +7057,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin27">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin27">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Turn-ins</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin23"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin23"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -7079,12 +7079,12 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin12">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin12">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Two-on sewing</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin11"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin10"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin11"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin10"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -7102,26 +7102,26 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin7">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin7">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Types of binding structure (Gathering term; do not assign)</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin5"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin43"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin88"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin118"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin135"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin398"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin136"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin256"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin264"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin315"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin418"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin9"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin407"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin235"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin150"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin137"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin5"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin43"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin88"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin118"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin135"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin398"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin136"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin256"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin264"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin315"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin418"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin9"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin407"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin235"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin150"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin137"/>
       <skos:scopeNote xml:lang="en">Gathering term; do not use; index under a narrower term.</skos:scopeNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
@@ -7145,22 +7145,22 @@
          <dcterms:date>2000-01-01</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin229">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin229">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Types of tools</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin73"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin227"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin248"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin230"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin42"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin111"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin271"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin231"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin359"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin272"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin250"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin251"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin73"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin227"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin248"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin230"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin42"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin111"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin271"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin231"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin359"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin272"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin250"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin251"/>
       <skos:scopeNote xml:lang="en">Gathering term; do not use; index under a narrower term.</skos:scopeNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
@@ -7179,11 +7179,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin394">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin394">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Unbound sheets</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin4"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin4"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -7201,11 +7201,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin410">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin410">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Unlettered bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin16"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin16"/>
       <skos:scopeNote xml:lang="en">Use for bindings with no title or author&#x92;s name on the spine or cover.</skos:scopeNote>
       <skos:historyNote xml:lang="en">Approved 6/2005.</skos:historyNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
@@ -7225,11 +7225,11 @@
          <dcterms:date>2007-01-09</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin399">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin399">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Unopened books</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin4"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin4"/>
       <skos:scopeNote xml:lang="en">Books in which the folded edges of the sections have not been trimmed away or opened by a utensil such as a knife.</skos:scopeNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
@@ -7248,13 +7248,13 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin289">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin289">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Unsupported sewing</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin11"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin288"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin345"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin11"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin288"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin345"/>
       <skos:scopeNote xml:lang="en">Gathering term; do not use; index under a narrower term.</skos:scopeNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
@@ -7273,13 +7273,13 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin206">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin206">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Untrimmed edges</skos:prefLabel>
       <skos:altLabel xml:lang="en">Edges, untrimmed</skos:altLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin171"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin392"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin171"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin392"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -7297,15 +7297,15 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin250">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin250">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Vegetal tools</skos:prefLabel>
       <skos:altLabel xml:lang="en">Vegetal rolls</skos:altLabel>
       <skos:altLabel xml:lang="en">Vegetal stamps</skos:altLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin229"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin248"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin251"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin229"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin248"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin251"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -7323,11 +7323,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin347">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin347">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Vellucent bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin295"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin295"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -7345,16 +7345,16 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin19">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin19">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Vellum bindings</skos:prefLabel>
       <skos:altLabel xml:lang="en">Parchment bindings</skos:altLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin16"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin390"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin15"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin17"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin18"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin16"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin390"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin15"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin17"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin18"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -7372,11 +7372,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin199">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin199">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Vellum doublures</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin24"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin24"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -7394,12 +7394,12 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin28">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin28">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Vellum endleaves</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin23"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin25"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin23"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin25"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -7417,11 +7417,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin29">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin29">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Vellum pastedowns</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin23"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin23"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -7439,11 +7439,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin393">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin393">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Vellum tapes</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin50"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin50"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -7461,11 +7461,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin395">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin395">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Vellum thongs</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin21"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin21"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -7483,11 +7483,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin402">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin402">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Vellum wrappers</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin150"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin150"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -7505,11 +7505,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin144">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin144">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Velvet bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin104"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin104"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -7527,11 +7527,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin405">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin405">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Visible structure</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin16"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin16"/>
       <skos:note xml:lang="en">Originally proposed to include bindings whose elements have become visible through wear; BSC edited scope to reflect only bindings whose elements were designed to be visible.</skos:note>
       <skos:historyNote xml:lang="en">Candidate term, 1/2006</skos:historyNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
@@ -7551,11 +7551,11 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin391">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin391">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Washing</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin368"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin368"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -7573,13 +7573,13 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin321">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin321">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Waste</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin16"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin320"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin364"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin16"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin320"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin364"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -7597,12 +7597,12 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin78">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin78">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Woodblock printed papers</skos:prefLabel>
       <skos:altLabel xml:lang="en">Block printed papers</skos:altLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin184"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin184"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -7620,13 +7620,13 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin332">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin332">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Wooden bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin16"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin426"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin91"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin16"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin426"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin91"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -7644,14 +7644,14 @@
          <dcterms:date>2012-06-26</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin91">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin91">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Wooden boards</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin88"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin426"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin381"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin332"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin88"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin426"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin381"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin332"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -7669,13 +7669,13 @@
          <dcterms:date>2012-06-26</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin113">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin113">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Worked headbands</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin26"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin112"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin99"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin26"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin112"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin99"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -7693,16 +7693,16 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin150">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin150">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Wrappers</skos:prefLabel>
       <skos:altLabel xml:lang="en">Paper wrappers</skos:altLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin7"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin148"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin357"/>
-      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin402"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin315"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin7"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin148"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin357"/>
+      <skos:narrower rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin402"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin315"/>
       <skos:scopeNote xml:lang="en">A physically attached flexible cover for a book.  Cf. Dust jacket.</skos:scopeNote>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
@@ -7721,13 +7721,13 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin137">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin137">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Yapp style bindings</skos:prefLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin7"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin135"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin136"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin7"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin135"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin136"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>
@@ -7745,15 +7745,15 @@
          <dcterms:date>2006-07-19</dcterms:date>
       </skos:changeNote>
    </rdf:Description>
-   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin251">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+   <rdf:Description rdf:about="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin251">
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">Zoomorphic tools</skos:prefLabel>
       <skos:altLabel xml:lang="en">Zoomorphic rolls</skos:altLabel>
       <skos:altLabel xml:lang="en">Zoomorphic stamps</skos:altLabel>
       <skos:inScheme rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1"/>
-      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin229"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin248"/>
-      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/rbms_binding_type/0.1/rbbin250"/>
+      <skos:broader rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin229"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin248"/>
+      <skos:related rdf:resource="https://w3id.org/arm/core/vocabularies/binding_type/0.1/rbbin250"/>
       <skos:editorialNote xml:lang="en">Approved</skos:editorialNote>
       <skos:changeNote rdf:parseType="Resource">
          <rdf:value>INP</rdf:value>

--- a/tools/rbms_vocabs/xsl/rbmsvocabs.xsl
+++ b/tools/rbms_vocabs/xsl/rbmsvocabs.xsl
@@ -44,7 +44,7 @@
       />
     </xsl:param>
     <rdf:Description rdf:about="{$uri}">
-      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept/"/>
+      <rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
       <skos:prefLabel xml:lang="en">
         <xsl:value-of select="DESCRIPTOR"/>
       </skos:prefLabel>


### PR DESCRIPTION
There was an extra slash at the end of the URI for skos:Concept in the RBMS Vocab XSLT.